### PR TITLE
Add animated Empatia poster layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Empatia Poster</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Space+Grotesk:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <main class="poster">
+        <div class="poster__texture"></div>
+        <div class="poster__content">
+          <p class="poster__title">Empatia</p>
+          <div class="poster__divider" aria-hidden="true"></div>
+          <p class="poster__subtitle">voicot.com</p>
+          <p class="poster__tagline">Liberacion Animal</p>
+          <p class="poster__hashtag">#DifusionV</p>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,263 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  color-scheme: light;
+  --poster-pink-1: #ff8bbd;
+  --poster-pink-2: #f75f9d;
+  --poster-pink-3: #ff6ea8;
+  --poster-shadow: rgba(0, 0, 0, 0.16);
+  --poster-border: rgba(255, 255, 255, 0.75);
+  --text-color: #121212;
+  --background-color: #f3eee5;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 4rem);
+  background: var(--background-color);
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  color: var(--text-color);
+}
+
+.page {
+  width: min(90vw, 720px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.poster {
+  position: relative;
+  width: min(100%, 640px);
+  aspect-ratio: 4 / 3;
+  padding: clamp(2rem, 5vw, 3.5rem) clamp(2rem, 6vw, 4rem);
+  border-radius: clamp(18px, 2vw, 28px);
+  background: linear-gradient(130deg, var(--poster-pink-1), var(--poster-pink-2), var(--poster-pink-3));
+  background-size: 160% 160%;
+  overflow: hidden;
+  box-shadow: 0 24px 60px -32px var(--poster-shadow), 0 8px 18px -12px rgba(0, 0, 0, 0.3);
+  animation: float 9s ease-in-out infinite, backdropFlow 18s ease-in-out infinite;
+}
+
+.poster::before {
+  content: "";
+  position: absolute;
+  inset: -18px;
+  background: var(--poster-border);
+  border-radius: inherit;
+  z-index: -2;
+  filter: blur(18px);
+  opacity: 0.6;
+}
+
+.poster::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.32);
+  mix-blend-mode: screen;
+}
+
+.poster__texture {
+  position: absolute;
+  inset: -20%;
+  background-image: radial-gradient(circle at 10% 20%, rgba(255, 255, 255, 0.22) 0, transparent 50%),
+    radial-gradient(circle at 80% 10%, rgba(255, 255, 255, 0.18) 0, transparent 52%),
+    radial-gradient(circle at 50% 80%, rgba(0, 0, 0, 0.15) 0, transparent 55%),
+    repeating-linear-gradient(120deg, rgba(255, 255, 255, 0.05) 0, rgba(255, 255, 255, 0.05) 2px, transparent 2px, transparent 6px);
+  opacity: 0.45;
+  mix-blend-mode: soft-light;
+  animation: textureDrift 22s linear infinite;
+}
+
+.poster__content {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  grid-template-rows: auto auto auto auto;
+  justify-items: center;
+  text-transform: uppercase;
+  gap: clamp(0.4rem, 1.4vw, 0.8rem);
+  letter-spacing: 0.12em;
+  z-index: 1;
+  text-align: center;
+}
+
+.poster__title {
+  font-family: "Oswald", "Arial Black", sans-serif;
+  font-size: clamp(2.75rem, 11vw, 6rem);
+  font-weight: 600;
+  letter-spacing: clamp(0.04em, 0.12em, 0.1em);
+  margin: 0;
+  text-shadow: 0 10px 18px rgba(0, 0, 0, 0.25);
+  animation: titlePulse 7s ease-in-out infinite;
+}
+
+.poster__divider {
+  width: clamp(90px, 35%, 180px);
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.75);
+  position: relative;
+  overflow: hidden;
+}
+
+.poster__divider::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.4), transparent);
+  animation: dividerShine 2.8s ease-in-out infinite;
+}
+
+.poster__subtitle,
+.poster__tagline,
+.poster__hashtag {
+  margin: 0;
+  font-family: "Oswald", "Arial Narrow", sans-serif;
+  font-weight: 500;
+  text-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+}
+
+.poster__subtitle {
+  font-size: clamp(1.1rem, 4vw, 2rem);
+  letter-spacing: 0.26em;
+  animation: subtitleRise 10s ease-in-out infinite;
+}
+
+.poster__tagline {
+  font-size: clamp(0.85rem, 3vw, 1.45rem);
+  letter-spacing: 0.45em;
+  animation: taglineDrift 8s ease-in-out infinite;
+}
+
+.poster__hashtag {
+  font-size: clamp(0.9rem, 3vw, 1.55rem);
+  letter-spacing: 0.35em;
+  animation: hashtagGlow 9s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(-6px) rotate(-0.4deg);
+  }
+  50% {
+    transform: translateY(6px) rotate(0.6deg);
+  }
+}
+
+@keyframes backdropFlow {
+  0% {
+    background-position: 0% 35%;
+  }
+  50% {
+    background-position: 100% 65%;
+  }
+  100% {
+    background-position: 0% 35%;
+  }
+}
+
+@keyframes textureDrift {
+  0% {
+    transform: translate3d(-4%, -2%, 0) scale(1.05) rotate(-1deg);
+  }
+  50% {
+    transform: translate3d(4%, 3%, 0) scale(1.08) rotate(1deg);
+  }
+  100% {
+    transform: translate3d(-4%, -2%, 0) scale(1.05) rotate(-1deg);
+  }
+}
+
+@keyframes titlePulse {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+    letter-spacing: clamp(0.04em, 0.12em, 0.1em);
+  }
+  50% {
+    transform: translateY(-8px) scale(1.04);
+    letter-spacing: clamp(0.08em, 0.16em, 0.14em);
+  }
+}
+
+@keyframes dividerShine {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes subtitleRise {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.94;
+  }
+  50% {
+    transform: translateY(-5px);
+    opacity: 1;
+  }
+}
+
+@keyframes taglineDrift {
+  0%,
+  100% {
+    transform: translateY(0) skewX(0deg);
+  }
+  50% {
+    transform: translateY(6px) skewX(-1deg);
+  }
+}
+
+@keyframes hashtagGlow {
+  0%,
+  100% {
+    text-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+  }
+  50% {
+    text-shadow: 0 0 20px rgba(255, 255, 255, 0.3);
+  }
+}
+
+@media (max-width: 560px) {
+  body {
+    padding: clamp(1rem, 5vw, 2rem);
+  }
+
+  .poster {
+    padding: clamp(1.8rem, 6vw, 2.4rem) clamp(1.4rem, 5vw, 2rem);
+  }
+
+  .poster__content {
+    gap: clamp(0.3rem, 1.4vw, 0.6rem);
+    letter-spacing: 0.1em;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- build an HTML page that recreates the Empatia poster with structured content and Google Fonts
- style the poster with animated gradients, texture overlays, and responsive typography to match the reference design
- add motion polish including floating, shine, and accessibility-friendly reduced-motion fallbacks

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdcd9cc214832c8a4cecc1c723a3a7